### PR TITLE
Fix bugs, add tests and add AsWKT for IEnumerable<Placemark>, supprt for LineString

### DIFF
--- a/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using SharpKml.Base;
+using SharpKml.Dom;
+using SharpKml_WKT.Base;
+using SharpKml_WKT.Dom;
+using SharpKml_WKT.Dom.Geometries;
+using Xunit;
+
+namespace SharpKml_WKT.Tests
+{
+    public class PlacemarkExtensionsTests
+    {
+        private Placemark _placemark;
+        private Polygon _polygon;
+        private MultipleGeometry _multipleGeometry;
+        private Placemark _multiplePlacemark;
+
+        public PlacemarkExtensionsTests()
+        {
+            _polygon = new Polygon
+            {
+                OuterBoundary = new OuterBoundary
+                {
+                    LinearRing = new LinearRing
+                    {
+                        Coordinates = new CoordinateCollection
+                        {
+                            new Vector
+                            {
+                                Longitude = 30,
+                                Latitude = 10
+                            },
+                            new Vector
+                            {
+                                Longitude = 40.5,
+                                Latitude = 40
+                            },
+                            new Vector
+                            {
+                                Longitude = 20,
+                                Latitude = 40
+                            },
+                            new Vector
+                            {
+                                Longitude = 10,
+                                Latitude = 20
+                            },
+                            new Vector
+                            {
+                                Longitude = 30,
+                                Latitude = 10
+                            }
+                        }
+                    }
+                }
+            };
+
+            _multipleGeometry = new MultipleGeometry();
+            _multipleGeometry.AddGeometry(new Polygon
+            {
+                OuterBoundary = new OuterBoundary
+                {
+                    LinearRing = new LinearRing
+                    {
+                        Coordinates = new CoordinateCollection
+                        {
+                            new Vector
+                            {
+                                Longitude = 30,
+                                Latitude = 20
+                            },
+                            new Vector
+                            {
+                                Longitude = 45,
+                                Latitude = 40
+                            },
+                            new Vector
+                            {
+                                Longitude = 10,
+                                Latitude = 40
+                            },
+                            new Vector
+                            {
+                                Longitude = 30,
+                                Latitude = 20
+                            },
+                        }
+                    }
+                }
+            });
+            _multipleGeometry.AddGeometry(new Polygon
+            {
+                OuterBoundary = new OuterBoundary
+                {
+                    LinearRing = new LinearRing
+                    {
+                        Coordinates = new CoordinateCollection
+                        {
+                            new Vector
+                            {
+                                Longitude = 15,
+                                Latitude = 5
+                            },
+                            new Vector
+                            {
+                                Longitude = 40,
+                                Latitude = 10
+                            },                            
+                            new Vector
+                            {
+                                Longitude = 10,
+                                Latitude = 20
+                            },        
+                            new Vector
+                            {
+                                Longitude =5,
+                                Latitude = 10
+                            },   
+                            new Vector
+                            {
+                                Longitude =15,
+                                Latitude = 5
+                            },
+                        }
+                    }
+                }
+            });
+            _placemark = new Placemark
+            {
+                Geometry = _polygon
+            };            
+            _multiplePlacemark = new Placemark
+            {
+                Geometry = _multipleGeometry
+            };
+        }
+
+        [Theory]
+        [InlineData("POLYGON ((30 10,")]
+        [InlineData("40.5 40,")]
+        [InlineData("20 40,")]
+        [InlineData("10 20,")]
+        [InlineData("30 10))")]
+        [InlineData("POLYGON ((30 10, 40.5 40, 20 40, 10 20, 30 10)")]
+        public void AsWKT_should_contain_substring(string subString)
+        {
+            //Act
+            var result = _placemark.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }
+        
+        [Theory]
+        [InlineData(-7.48953, 38.897902, "38.897902 -7.48953")]
+        public void Vector_AsCoordinatePair_should_return_correct_result(double latitude, double longitude, string expectedString)
+        {
+            //Arrange
+            var vector = new Vector
+            {
+                Altitude = 0,
+                Latitude = latitude,
+                Longitude = longitude
+            };
+
+            //Act
+            var result = vector.AsCoordinatePair();
+
+            //Assert
+            result.Should().Contain(expectedString);
+        }
+
+        [Theory]
+        [InlineData("(30 10,")]
+        [InlineData("40.5 40,")]
+        [InlineData("20 40")]
+        [InlineData("10 20,")]
+        [InlineData("30 10)")]
+        public void VectorArrayArray_AsWKT_should_contin_substring(string substring)
+        {
+            //Act
+            var result = _polygon.AsVectorCoordinates().AsWKT();
+
+            //Assert
+            result.Should().Contain(substring);
+        }
+        
+        [Theory]
+        [InlineData("MULTIPOLYGON (((30 20,")]
+        [InlineData("45 40,")]
+        [InlineData("10 40,")]
+        [InlineData("30 20)),")]
+        [InlineData("((15 5,")]
+        [InlineData("40 10,")]
+        [InlineData("10 20,")]
+        [InlineData("5 10,")]
+        [InlineData("15 5)))")]
+        [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))")]
+        public void MultiplePlacemark_AsWKT_should_contain_substring(string substring)
+        {
+            //Act
+            var result = _multiplePlacemark.AsWKT();
+
+            //Assert
+            result.Should().Contain(substring);
+        }
+    }
+}

--- a/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
@@ -14,6 +14,7 @@ namespace SharpKml_WKT.Tests
         private Polygon _polygon;
         private MultipleGeometry _multipleGeometry;
         private Placemark _multiplePlacemark;
+        private Placemark _placemarkWithHole;
 
         public PlacemarkExtensionsTests()
         {
@@ -54,6 +55,73 @@ namespace SharpKml_WKT.Tests
                     }
                 }
             };
+
+            var polygonWithHole = new Polygon
+            {
+                OuterBoundary = new OuterBoundary
+                {
+                    LinearRing = new LinearRing
+                    {
+                        Coordinates = new CoordinateCollection
+                        {
+                            new Vector
+                            {
+                                Longitude = 35,
+                                Latitude = 10
+                            },
+                            new Vector
+                            {
+                                Longitude = 45,
+                                Latitude = 45
+                            },
+                            new Vector
+                            {
+                                Longitude = 15,
+                                Latitude = 40
+                            },
+                            new Vector
+                            {
+                                Longitude = 10,
+                                Latitude = 20
+                            },
+                            new Vector
+                            {
+                                Longitude = 35,
+                                Latitude = 10
+                            }
+                        }
+                    }
+                }
+            };
+            polygonWithHole.AddInnerBoundary(new InnerBoundary
+            {
+                LinearRing = new LinearRing
+                {
+                    Coordinates = new CoordinateCollection
+                    {
+                        new Vector
+                        {
+                            Longitude = 20,
+                            Latitude = 30
+                        },
+                        new Vector
+                        {
+                            Longitude = 35,
+                            Latitude = 35
+                        },
+                        new Vector
+                        {
+                            Longitude = 30,
+                            Latitude = 20
+                        },
+                        new Vector
+                        {
+                            Longitude = 20,
+                            Latitude = 30
+                        }
+                    }
+                }
+            });
 
             _multipleGeometry = new MultipleGeometry();
             _multipleGeometry.AddGeometry(new Polygon
@@ -105,17 +173,17 @@ namespace SharpKml_WKT.Tests
                             {
                                 Longitude = 40,
                                 Latitude = 10
-                            },                            
+                            },
                             new Vector
                             {
                                 Longitude = 10,
                                 Latitude = 20
-                            },        
+                            },
                             new Vector
                             {
                                 Longitude =5,
                                 Latitude = 10
-                            },   
+                            },
                             new Vector
                             {
                                 Longitude =15,
@@ -129,6 +197,10 @@ namespace SharpKml_WKT.Tests
             {
                 Geometry = _polygon
             };            
+            _placemarkWithHole = new Placemark
+            {
+                Geometry = polygonWithHole
+            };
             _multiplePlacemark = new Placemark
             {
                 Geometry = _multipleGeometry
@@ -149,8 +221,19 @@ namespace SharpKml_WKT.Tests
 
             //Assert
             result.Should().Contain(subString);
-        }
+        }        
         
+        [Theory]
+        [InlineData("POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))")]
+        public void AsWKT_should_contain_substring_for_polygon_with_hole(string subString)
+        {
+            //Act
+            var result = _placemarkWithHole.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }
+
         [Theory]
         [InlineData(-7.48953, 38.897902, "38.897902 -7.48953")]
         public void Vector_AsCoordinatePair_should_return_correct_result(double latitude, double longitude, string expectedString)
@@ -176,7 +259,7 @@ namespace SharpKml_WKT.Tests
         [InlineData("20 40")]
         [InlineData("10 20,")]
         [InlineData("30 10)")]
-        public void VectorArrayArray_AsWKT_should_contin_substring(string substring)
+        public void VectorArrayArray_AsWKT_should_contain_substring(string substring)
         {
             //Act
             var result = _polygon.AsVectorCoordinates().AsWKT();
@@ -184,7 +267,7 @@ namespace SharpKml_WKT.Tests
             //Assert
             result.Should().Contain(substring);
         }
-        
+
         [Theory]
         [InlineData("MULTIPOLYGON (((30 20,")]
         [InlineData("45 40,")]
@@ -210,63 +293,63 @@ namespace SharpKml_WKT.Tests
         public void PlaceMark_array_AsWKT_should_return_correct_result_for_single_polygon(string subString)
         {
             //Arrange
-            var placemarkArray = new[] {_placemark};
+            var placemarkArray = new[] { _placemark };
 
             //Act
             var result = placemarkArray.AsWKT();
 
             //Assert
             result.Should().Contain(subString);
-        } 
-        
+        }
+
         [Theory]
         [InlineData("MULTIPOLYGON (((30 10, 40.5 40, 20 40, 10 20, 30 10)),((30 10, 40.5 40, 20 40, 10 20, 30 10)))")]
         public void PlaceMark_array_AsWKT_should_return_correct_result_for_two_polygon(string subString)
         {
             //Arrange
-            var placemarkArray = new[] {_placemark, _placemark};
+            var placemarkArray = new[] { _placemark, _placemark };
 
             //Act
             var result = placemarkArray.AsWKT();
 
             //Assert
             result.Should().Contain(subString);
-        }        
-        
+        }
+
         [Theory]
         [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))")]
         public void PlaceMark_array_AsWKT_should_return_correct_result_for_single_multiple_polygon(string subString)
         {
             //Arrange
-            var placemarkArray = new[] {_multiplePlacemark};
+            var placemarkArray = new[] { _multiplePlacemark };
 
             //Act
             var result = placemarkArray.AsWKT();
 
             //Assert
             result.Should().Contain(subString);
-        }        
-        
+        }
+
         [Theory]
         [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))")]
         public void PlaceMark_array_AsWKT_should_return_correct_result_for_two_multiple_polygon(string subString)
         {
             //Arrange
-            var placemarkArray = new[] {_multiplePlacemark, _multiplePlacemark};
+            var placemarkArray = new[] { _multiplePlacemark, _multiplePlacemark };
 
             //Act
             var result = placemarkArray.AsWKT();
 
             //Assert
             result.Should().Contain(subString);
-        }        
-        
+        }
+
         [Theory]
         [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)),((30 10, 40.5 40, 20 40, 10 20, 30 10)))")]
         public void PlaceMark_array_AsWKT_should_return_correct_result_for_multiple_polygon_and_polygon(string subString)
         {
             //Arrange
-            var placemarkArray = new[] {_multiplePlacemark, _placemark};
+            var placemarkArray = new[] { _multiplePlacemark, _placemark };
 
             //Act
             var result = placemarkArray.AsWKT();

--- a/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
@@ -265,6 +265,17 @@ namespace SharpKml_WKT.Tests
 
             //Assert
             result.Should().Contain(subString);
+        }          
+        
+        [Theory]
+        [InlineData("POLYGON ((30 10, 10 30, 40 40))")]
+        public void AsWKT_for_placemark_with_linestring_and_convert_to_polygon_should_contain_substring(string subString)
+        {
+            //Act
+            var result = _placemarkWithLinestring.AsWKT(true);
+
+            //Assert
+            result.Should().Contain(subString);
         }        
         
         [Theory]
@@ -411,6 +422,76 @@ namespace SharpKml_WKT.Tests
 
             //Act
             var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }        
+        
+        [Theory]
+        [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)),((30 10, 10 30, 40 40)))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_multiple_polygon_and_linestring_with_convertLineStringToPolygon_as_true(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] { _multiplePlacemark, _placemarkWithLinestring };
+
+            //Act
+            var result = placemarkArray.AsWKT(true);
+
+            //Assert
+            result.Should().Contain(subString);
+        }        
+        
+        [Theory]
+        [InlineData("MULTILINESTRING ((30 10, 10 30, 40 40),(30 10, 10 30, 40 40))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_multiple_linestrings(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] { _placemarkWithLinestring, _placemarkWithLinestring };
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }        
+        
+        [Theory]
+        [InlineData("LINESTRING (30 10, 10 30, 40 40)")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_linestring(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] { _placemarkWithLinestring };
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }
+
+        [Theory]
+        [InlineData("POLYGON ((30 10, 10 30, 40 40))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_linestring_with_convertLineStringToPolygon(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] { _placemarkWithLinestring };
+
+            //Act
+            var result = placemarkArray.AsWKT(true);
+
+            //Assert
+            result.Should().Contain(subString);
+        }
+
+        [Theory]
+        [InlineData("MULTIPOLYGON (((30 10, 10 30, 40 40)),((30 10, 10 30, 40 40)))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_linestrings_with_convertLineStringToPolygon(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] { _placemarkWithLinestring, _placemarkWithLinestring };
+
+            //Act
+            var result = placemarkArray.AsWKT(true);
 
             //Assert
             result.Should().Contain(subString);

--- a/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using SharpKml.Base;
@@ -495,6 +496,16 @@ namespace SharpKml_WKT.Tests
 
             //Assert
             result.Should().Contain(subString);
+        }
+
+        [Fact]
+        public void PlaceMark_array_AsWKT_should_return_throw_exception_for__mixed_polygons_and_linestrings_with_convertLineStringToPolygon_as_false()
+        {
+            //Arrange
+            var placemarkArray = new[] { _placemark, _placemarkWithLinestring };
+
+            //Act & Assert
+            placemarkArray.Invoking(x => x.AsWKT()).Should().Throw<NotImplementedException>();
         }
     }
 }

--- a/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
@@ -83,7 +83,7 @@ namespace SharpKml_WKT.Tests
                             {
                                 Longitude = 30,
                                 Latitude = 20
-                            },
+                            }
                         }
                     }
                 }
@@ -120,7 +120,7 @@ namespace SharpKml_WKT.Tests
                             {
                                 Longitude =15,
                                 Latitude = 5
-                            },
+                            }
                         }
                     }
                 }
@@ -203,6 +203,76 @@ namespace SharpKml_WKT.Tests
 
             //Assert
             result.Should().Contain(substring);
+        }
+
+        [Theory]
+        [InlineData("POLYGON ((30 10, 40.5 40, 20 40, 10 20, 30 10))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_single_polygon(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] {_placemark};
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        } 
+        
+        [Theory]
+        [InlineData("MULTIPOLYGON (((30 10, 40.5 40, 20 40, 10 20, 30 10)),((30 10, 40.5 40, 20 40, 10 20, 30 10)))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_two_polygon(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] {_placemark, _placemark};
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }        
+        
+        [Theory]
+        [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_single_multiple_polygon(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] {_multiplePlacemark};
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }        
+        
+        [Theory]
+        [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)),((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_two_multiple_polygon(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] {_multiplePlacemark, _multiplePlacemark};
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }        
+        
+        [Theory]
+        [InlineData("MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)),((15 5, 40 10, 10 20, 5 10, 15 5)),((30 10, 40.5 40, 20 40, 10 20, 30 10)))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_multiple_polygon_and_polygon(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] {_multiplePlacemark, _placemark};
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
         }
     }
 }

--- a/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using FluentAssertions;
 using SharpKml.Base;
 using SharpKml.Dom;
@@ -16,6 +17,7 @@ namespace SharpKml_WKT.Tests
         private Placemark _multiplePlacemark;
         private Placemark _placemarkWithHole;
         private Placemark _placemarkWithPoint;
+        private Placemark _placemarkWithLinestring;
 
         public PlacemarkExtensionsTests()
         {
@@ -194,6 +196,28 @@ namespace SharpKml_WKT.Tests
                     }
                 }
             });
+
+            var linestring = new LineString
+            {
+                Coordinates = new CoordinateCollection(new List<Vector>
+                {
+                    new Vector
+                    {
+                        Longitude = 30,
+                        Latitude = 10
+                    },
+                    new Vector
+                    {
+                        Longitude = 10,
+                        Latitude = 30
+                    },
+                    new Vector
+                    {
+                        Longitude = 40,
+                        Latitude = 40
+                    }
+                })
+            };
             _placemark = new Placemark
             {
                 Geometry = _polygon
@@ -210,6 +234,10 @@ namespace SharpKml_WKT.Tests
             {
                 Geometry = new Point {Coordinate = new Vector(15, 5)}
             };
+            _placemarkWithLinestring = new Placemark
+            {
+                Geometry = linestring
+            };
         }
 
         [Theory]
@@ -223,6 +251,17 @@ namespace SharpKml_WKT.Tests
         {
             //Act
             var result = _placemark.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }         
+        
+        [Theory]
+        [InlineData("LINESTRING (30 10, 10 30, 40 40)")]
+        public void AsWKT_for_placemark_with_linestring_should_contain_substring(string subString)
+        {
+            //Act
+            var result = _placemarkWithLinestring.AsWKT();
 
             //Assert
             result.Should().Contain(subString);

--- a/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/PlacemarkExtensionsTests.cs
@@ -15,6 +15,7 @@ namespace SharpKml_WKT.Tests
         private MultipleGeometry _multipleGeometry;
         private Placemark _multiplePlacemark;
         private Placemark _placemarkWithHole;
+        private Placemark _placemarkWithPoint;
 
         public PlacemarkExtensionsTests()
         {
@@ -205,6 +206,10 @@ namespace SharpKml_WKT.Tests
             {
                 Geometry = _multipleGeometry
             };
+            _placemarkWithPoint = new Placemark
+            {
+                Geometry = new Point {Coordinate = new Vector(15, 5)}
+            };
         }
 
         [Theory]
@@ -294,6 +299,20 @@ namespace SharpKml_WKT.Tests
         {
             //Arrange
             var placemarkArray = new[] { _placemark };
+
+            //Act
+            var result = placemarkArray.AsWKT();
+
+            //Assert
+            result.Should().Contain(subString);
+        }        
+        
+        [Theory]
+        [InlineData("POLYGON ((30 10, 40.5 40, 20 40, 10 20, 30 10))")]
+        public void PlaceMark_array_AsWKT_should_return_correct_result_for_single_polygon_and_point(string subString)
+        {
+            //Arrange
+            var placemarkArray = new[] { _placemark, _placemarkWithPoint };
 
             //Act
             var result = placemarkArray.AsWKT();

--- a/SharpKml-WKT/SharpKml-WKT.Tests/SharpKml-WKT.Tests.csproj
+++ b/SharpKml-WKT/SharpKml-WKT.Tests/SharpKml-WKT.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>SharpKml_WKT.Tests</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SharpKml-WKT\SharpKml-WKT.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SharpKml-WKT/SharpKml-WKT.sln
+++ b/SharpKml-WKT/SharpKml-WKT.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2050
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpKml-WKT", "SharpKml-WKT\SharpKml-WKT.csproj", "{ED7B1AFC-E4C0-4235-9A7C-2E3FE428BE20}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpKml-WKT", "SharpKml-WKT\SharpKml-WKT.csproj", "{ED7B1AFC-E4C0-4235-9A7C-2E3FE428BE20}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpKml-WKT.Tests", "SharpKml-WKT.Tests\SharpKml-WKT.Tests.csproj", "{42AFA4F0-3D2C-4811-B319-C0F4DC35A97C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{ED7B1AFC-E4C0-4235-9A7C-2E3FE428BE20}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED7B1AFC-E4C0-4235-9A7C-2E3FE428BE20}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED7B1AFC-E4C0-4235-9A7C-2E3FE428BE20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42AFA4F0-3D2C-4811-B319-C0F4DC35A97C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42AFA4F0-3D2C-4811-B319-C0F4DC35A97C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42AFA4F0-3D2C-4811-B319-C0F4DC35A97C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42AFA4F0-3D2C-4811-B319-C0F4DC35A97C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SharpKml-WKT/SharpKml-WKT/Base/VectorExtensions.cs
+++ b/SharpKml-WKT/SharpKml-WKT/Base/VectorExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using SharpKml.Base;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -31,7 +32,7 @@ namespace SharpKml_WKT.Base
 
 		public static string AsCoordinatePair(this Vector coordinate)
 		{
-			return $"{coordinate.Longitude} {coordinate.Latitude}";
+			return $"{coordinate.Longitude.ToString(CultureInfo.InvariantCulture)} {coordinate.Latitude.ToString(CultureInfo.InvariantCulture)}";
 		}
 	}
 }

--- a/SharpKml-WKT/SharpKml-WKT/Dom/Geometries/CoordinateCollectionExtenstions.cs
+++ b/SharpKml-WKT/SharpKml-WKT/Dom/Geometries/CoordinateCollectionExtenstions.cs
@@ -1,0 +1,20 @@
+﻿using SharpKml.Base;
+using SharpKml.Dom;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SharpKml_WKT.Dom.Geometries
+{
+	/// <summary>
+	/// Provides extension methods for <see cref="Polygon"/> objects.
+	/// </summary>
+	public static class CoordinateCollectionExtenstions
+	{
+		public static Vector[][] AsVectorCoordinates(this CoordinateCollection coordinateCollection)
+		{
+            List<List<Vector>> coordinates = new List<List<Vector>> {new List<Vector>()};
+            coordinates[0].AddRange(coordinateCollection);
+			return coordinates.Select(c => c.ToArray()).ToArray();
+		}
+	}
+}

--- a/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
+++ b/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
@@ -93,7 +93,7 @@ namespace SharpKml_WKT.Dom
 		private static string GenerateMultiplePolygonWKT(List<Vector[][]> polygons)
 		{
 			StringBuilder sb = new StringBuilder();
-			sb.Append("MULTIPOLYGON(");
+			sb.Append("MULTIPOLYGON (");
 			sb.Append(polygons[0].AsWKT());
 			foreach (var polygon in polygons.Skip(1))
 			{
@@ -117,10 +117,9 @@ namespace SharpKml_WKT.Dom
 		private static string GeneratePolygonWKT(Vector[][] polygon)
 		{
 			StringBuilder sb = new StringBuilder();
-			sb.Append("POLYGON(");
+			sb.Append("POLYGON ");
 			sb.Append(polygon.AsWKT());
-			sb.Append(")");
-			return sb.ToString();
+            return sb.ToString();
 		}
 	}
 }

--- a/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
+++ b/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
@@ -59,7 +59,6 @@ namespace SharpKml_WKT.Dom
 		/// placemark.
 		/// </returns>
 		/// <exception cref="ArgumentNullException">placemark is null.</exception>
-		/// <exception cref="ArgumentException">placemark geometry is not a MultipleGeometry or Polygon.</exception>
 		public static string AsWKT(this IEnumerable<Placemark> placemarks)
 		{
 			if (placemarks == null)
@@ -67,12 +66,7 @@ namespace SharpKml_WKT.Dom
 				throw new ArgumentNullException();
 			}
 
-            var placemarkArray = placemarks.ToArray();
-			if(placemarkArray.Any(p => !(p.Geometry is MultipleGeometry) && !(p.Geometry is Polygon)))
-            {
-                throw new NotImplementedException("Only implemented types are Polygon and MultiplePolygon");
-			}
-
+            var placemarkArray = placemarks.Where(p => p.Geometry is MultipleGeometry || p.Geometry is Polygon).ToArray();
             List<Vector[][]> coordinates = placemarkArray.SelectMany(p => p.ConvertToCoordinates()).ToList();
 			if (coordinates.Count > 1)
 			{

--- a/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
+++ b/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
@@ -50,6 +50,39 @@ namespace SharpKml_WKT.Dom
 		}
 
 		/// <summary>
+		/// Generates a WKT string for the polygons in a Placemark <see cref="Placemark"/>.
+		/// Currently only supports placemarks with MultipleGeometry or Polygon Geometries.
+		/// </summary>
+		/// <param name="placemark">The placemark instance.</param>
+		/// <returns>
+		/// A <c>string</c> containing the well known text string for the geometry in the
+		/// placemark.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">placemark is null.</exception>
+		/// <exception cref="ArgumentException">placemark geometry is not a MultipleGeometry or Polygon.</exception>
+		public static string AsWKT(this IEnumerable<Placemark> placemarks)
+		{
+			if (placemarks == null)
+			{
+				throw new ArgumentNullException();
+			}
+
+            var placemarkArray = placemarks.ToArray();
+			if(placemarkArray.Any(p => !(p.Geometry is MultipleGeometry) && !(p.Geometry is Polygon)))
+            {
+                throw new NotImplementedException("Only implemented types are Polygon and MultiplePolygon");
+			}
+
+            List<Vector[][]> coordinates = placemarkArray.SelectMany(p => p.ConvertToCoordinates()).ToList();
+			if (coordinates.Count > 1)
+			{
+				return GenerateMultiplePolygonWKT(coordinates);
+			}
+
+			return GeneratePolygonWKT(coordinates.FirstOrDefault());
+		}
+
+		/// <summary>
 		/// Generates a List of arrays of Vectors for each Polygon in the Placemark <see cref="Placemark"/>.
 		/// </summary>
 		/// <param name="placemark">The placemark instance.</param>

--- a/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
+++ b/SharpKml-WKT/SharpKml-WKT/Dom/PlacemarkExtensions.cs
@@ -55,18 +55,19 @@ namespace SharpKml_WKT.Dom
 
 		}
 
-        /// <summary>
-        /// Generates a WKT string for the polygons in a Placemark <see cref="Placemark"/>.
-        /// Currently only supports placemarks with MultipleGeometry, Polygon or LineString Geometries .
-        /// </summary>
-        /// <param name="placemark">The placemark instance.</param>
-        /// <param name="convertLineStringToPolygon">If line strings should be converted to polygons</param>
-        /// <returns>
-        /// A <c>string</c> containing the well known text string for the geometry in the
-        /// placemark.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">placemark is null.</exception>
-        public static string AsWKT(this IEnumerable<Placemark> placemarks, bool convertLineStringToPolygon = false)
+		/// <summary>
+		/// Generates a WKT string for the polygons in a Placemark <see cref="Placemark"/>.
+		/// Currently only supports placemarks with MultipleGeometry, Polygon or LineString Geometries .
+		/// </summary>
+		/// <param name="placemark">The placemark instance.</param>
+		/// <param name="convertLineStringToPolygon">If line strings should be converted to polygons</param>
+		/// <returns>
+		/// A <c>string</c> containing the well known text string for the geometry in the
+		/// placemark.
+		/// </returns>
+		/// <exception cref="ArgumentNullException">Placemark is null.</exception>
+		/// <exception cref="NotImplementedException">Mix of linestring and polygon or MultipleGeometry when convertLineStringToPolygon is false</exception>
+		public static string AsWKT(this IEnumerable<Placemark> placemarks, bool convertLineStringToPolygon = false)
 		{
 			if (placemarks == null)
 			{
@@ -74,6 +75,11 @@ namespace SharpKml_WKT.Dom
 			}
 
             var placemarkArray = placemarks.Where(p => p.Geometry is MultipleGeometry || p.Geometry is Polygon || p.Geometry is LineString).ToArray();
+            if (!convertLineStringToPolygon && placemarkArray.Any(x => x.Geometry is LineString) &&
+                placemarkArray.Any(x => x.Geometry is Polygon || x.Geometry is MultipleGeometry))
+            {
+				throw new NotImplementedException("Placemarks with mix of LineString and Polygon or MultipleGeometry is not supported when convertLineStringToPolygon is false");
+            }
             List<Vector[][]> coordinates = placemarkArray.SelectMany(p => p.ConvertToCoordinates()).ToList();
             if (!convertLineStringToPolygon && placemarkArray.All(p => p.Geometry is LineString))
             {


### PR DESCRIPTION
I fixed a bug where Vector.AsCoordinatePair would return "," instead of "." in cultures (such as Swedish) that use "," as NumberDecimalSeparator.

I also fixed a bug where to many paranteses were added for POLYGON (3 at the start instead of 2).

I added a new extension method ASWKT for IEnumerable<Placemark>.

I added support for LineString.

I added unit tests based on [examples](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry).